### PR TITLE
Tunnel fixes for #147 and #148

### DIFF
--- a/tunnel/data/tunnel/functions/exit/nauseate.mcfunction
+++ b/tunnel/data/tunnel/functions/exit/nauseate.mcfunction
@@ -1,6 +1,18 @@
 #Nauseate tunnel occupants
 
 effect give @a[scores={TunnelOccupant=1..}] minecraft:nausea 10 0 true
+
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:item.book.page_turn voice @s ~ ~ ~ 1 1 1
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:item.book.page_turn voice @s ~ ~ ~ 1 0.90 1
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:item.book.page_turn voice @s ~ ~ ~ 1 0.80 1
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:item.book.page_turn voice @s ~ ~ ~ 1 0.70 1
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:item.book.page_turn voice @s ~ ~ ~ 1 0.60 1
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:item.book.page_turn voice @s ~ ~ ~ 1 0.50 1
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:item.book.page_turn voice @s ~ ~ ~ 1 0.40 1
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:item.book.page_turn voice @s ~ ~ ~ 1 0.30 1
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:item.book.page_turn voice @s ~ ~ ~ 1 0.20 1
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:item.book.page_turn voice @s ~ ~ ~ 1 0.10 1
+execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:entity.ender_dragon.ambient voice @s ~ ~ ~ 0.1 0.75 0.1
 execute as @a[scores={TunnelOccupant=1..}] at @s run playsound minecraft:ambient.underwater.loop.additions.ultra_rare voice @s ~ ~ ~ 2 2 1
 execute in overworld run schedule function tunnel:exit/kickall 100
 

--- a/tunnel/data/tunnel/functions/stage3/futuredoorsmokes.mcfunction
+++ b/tunnel/data/tunnel/functions/stage3/futuredoorsmokes.mcfunction
@@ -1,7 +1,7 @@
 #Future Door smoke
 
-execute in the_end run particle minecraft:campfire_signal_smoke 2855.5 30.5 2772.5 0.1 0.1 0.1 0.01 1
-execute in the_end run particle minecraft:lava 2855.5 30.5 2772.5 0.1 0.1 0.1 0.01 3
+execute in the_end run particle minecraft:campfire_signal_smoke 2855.5 30.5 2772.5 0.1 0.1 0.1 0.01 1 force
+execute in the_end run particle minecraft:lava 2855.5 30.5 2772.5 0.1 0.1 0.1 0.01 3 force
 execute in the_end if score CurrentLevel Tunnel matches 330..340 if entity @a[scores={TunnelOccupant=1..}] if block 2855 24 2772 minecraft:campfire in overworld run schedule function tunnel:stage3/futuredoorsmokes 10
 
 #Verbosity

--- a/tunnel/data/tunnel/functions/stage3/presentdoorsmokes.mcfunction
+++ b/tunnel/data/tunnel/functions/stage3/presentdoorsmokes.mcfunction
@@ -1,7 +1,7 @@
 #Door smoke
 
-execute in the_end run particle minecraft:campfire_signal_smoke 2858.5 30.5 2771.5 0.1 0.1 0.1 0.01 1
-execute in the_end run particle minecraft:lava 2858.5 30.5 2771.5 0.1 0.1 0.1 0.01 3
+execute in the_end run particle minecraft:campfire_signal_smoke 2858.5 30.5 2771.5 0.1 0.1 0.1 0.01 1 force
+execute in the_end run particle minecraft:lava 2858.5 30.5 2771.5 0.1 0.1 0.1 0.01 3 force
 execute in the_end if score CurrentLevel Tunnel matches 330..350 if entity @a[scores={TunnelOccupant=1..}] if block 2858 24 2771 minecraft:campfire in overworld run schedule function tunnel:stage3/presentdoorsmokes 10
 
 #Verbosity


### PR DESCRIPTION
Aims to address two outstanding issues: 

https://github.com/DaMarine/Slabserver-Staff/issues/147 - Now plays a dragon roar upon the nauseate effect activating, as well as an echoing page turning sound effect designed to sound like someone thumbing through a book.

https://github.com/DaMarine/Slabserver-Staff/issues/148 - Forces our smoke and lava particle effects around the door, to aid those using minimal particle settings. Afaik this is already the case with naturally generated campfire particles, and so those from beneath the floor do not need to be addressed.